### PR TITLE
Fix AppStream validation, add license, improve metainfo

### DIFF
--- a/me.proton.Authenticator.metainfo.xml
+++ b/me.proton.Authenticator.metainfo.xml
@@ -10,16 +10,11 @@
     <project_license>GPL-3.0</project_license>
     <developer id="ch.protonmail">
         <name>Proton AG</name>
-        <url>https://proton.me</url>
-        <address>Route de la Galaise 32, 1228 Plan-les-Ouates, Geneva, Switzerland</address>
     </developer>
     <project_group>Proton</project_group>
 
     <description>
-        <p>
-            NOTE: This is a wrapper of the official packages, but it is not verified, affiliated
-            with, or supported by Proton AG.
-        </p>
+        <p>NOTE: This is a community package of Proton Authenticator and is not officially supported by Proton AG.</p>
 
         <p>Proton Authenticator is an open-source, end-to-end encrypted two-factor authentication
             (2FA) app that generates one-time codes locally on your device and securely syncs them
@@ -28,7 +23,7 @@
         <p>Use Proton Authenticator to store and generate TOTP codes, import existing tokens, back
             up or sync securely across devices, lock the app with biometrics or a PIN, and access
             codes offline. A Proton Account is optional — syncing across non-Apple devices uses
-            Proton’s encrypted sync; iCloud backup/sync is available for Apple users.</p>
+            Proton's encrypted sync; iCloud backup/sync is available for Apple users.</p>
 
         <p>Proton Authenticator provides:</p>
         <ul>
@@ -60,23 +55,72 @@
 
     <url type="homepage">https://proton.me/authenticator</url>
     <url type="vcs-browser">https://github.com/ProtonMail/WebClients</url>
+    <url type="bugtracker">https://github.com/ProtonMail/WebClients/issues</url>
     <url type="help">https://proton.me/support/authenticator</url>
     <url type="translate">https://proton.me/blog/translation-community</url>
 
     <launchable type="desktop-id">me.proton.Authenticator.desktop</launchable>
     <screenshots>
-        <screenshot type="default" xml:lang="en">
-            <image>
-                https://pmecdn.protonweb.com/image-transformation/?s=s&amp;image=all_devices_desktop_fd3fbc771d.png&amp;width=3072&amp;height=2154</image>
-            <caption>Proton Authenticator — app overview</caption>
+        <screenshot type="default">
+            <image>https://pmecdn.protonweb.com/image-transformation/?s=s&amp;image=all_devices_desktop_fd3fbc771d.png&amp;width=3072&amp;height=2154</image>
+            <caption xml:lang="en">Proton Authenticator — app overview</caption>
         </screenshot>
     </screenshots>
 
     <content_rating type="oars-1.1">
-        <content_attribute id="money-purchasing">intense</content_attribute>
+        <content_attribute id="money-purchasing">none</content_attribute>
+        <content_attribute id="social-info">mild</content_attribute>
     </content_rating>
 
     <releases>
-        <release version="1.1.4" date="2025-09-19"></release>
+        <release version="1.1.4" date="2025-09-15">
+            <description>
+                <ul>
+                    <li>Fix duplicate keyring entries edge-case</li>
+                </ul>
+            </description>
+        </release>
+        <release version="1.1.3" date="2025-09-08">
+            <description>
+                <ul>
+                    <li>Migrate to encrypted automatic backup</li>
+                    <li>Fix app-crash on code generation errors</li>
+                    <li>Fix automatic backup pruning</li>
+                </ul>
+            </description>
+        </release>
+        <release version="1.1.2" date="2025-09-05">
+            <description>
+                <ul>
+                    <li>Regenerate OTP code immediately after item edit</li>
+                    <li>Improve external importers</li>
+                    <li>Tolerate partial remote syncing during import</li>
+                    <li>Fix sync issues with regards to primary user key changes</li>
+                    <li>Fix in-app crash when dragged item is deleted</li>
+                </ul>
+            </description>
+        </release>
+        <release version="1.1.1" date="2025-09-03">
+            <description>
+                <ul>
+                    <li>Improve app and biometrics stability</li>
+                </ul>
+            </description>
+        </release>
+        <release version="1.1.0" date="2025-09-02">
+            <description>
+                <ul>
+                    <li>Support encrypted import/export</li>
+                    <li>Support encrypted automatic backups</li>
+                    <li>Fix "How to use" and "Send feedback" buttons</li>
+                    <li>Improve app performance and stability</li>
+                </ul>
+            </description>
+        </release>
+        <release version="1.0.0" date="2025-07-31">
+            <description>
+                <p>Initial release of Proton Authenticator for Linux.</p>
+            </description>
+        </release>
     </releases>
 </component>

--- a/me.proton.Authenticator.yml
+++ b/me.proton.Authenticator.yml
@@ -16,16 +16,17 @@ modules:
     buildsystem: simple
     build-commands:
       - bsdtar -Oxf ProtonAuthenticator.deb data.tar.gz | bsdtar -xf -
+      - install -Dm644 usr/share/doc/proton-authenticator/copyright ${FLATPAK_DEST}/share/licenses/${FLATPAK_ID}/LICENSE
       - install -Dm 755 "usr/bin/proton-authenticator" ${FLATPAK_DEST}/bin/proton-authenticator
-      - install -Dm 644 me.proton.Authenticator.png /app/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png
+      - install -Dm 644 me.proton.Authenticator.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png
       - install -Dm644 "usr/share/applications/Proton Authenticator.desktop" "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
       - desktop-file-edit --set-key=Exec --set-value='proton-authenticator %U' --set-icon=${FLATPAK_ID} --remove-key=Comment
         "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
-      - install -Dm644 me.proton.Authenticator.metainfo.xml /app/share/metainfo/$FLATPAK_ID.metainfo.xml
+      - install -Dm644 me.proton.Authenticator.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
     sources:
       - type: file
         dest-filename: ProtonAuthenticator.deb
-        only-arches: [x86_64]
+        only-arches: [x86_64] # Upstream only ships an x86_64 binary; building from source is not yet feasible due to the monorepo structure
         url: https://proton.me/download/authenticator/linux/ProtonAuthenticator_1.1.4_amd64.deb
         # The upstream publishes sha512sum
         sha512: f442dbf6c798586316f0e49cdfec999787cee3a0e1b42d43a868405e4f1f33496eb9e20a15209ad31595b26ac795eb7808bc10c341658c89732727bef5ca55de
@@ -35,6 +36,7 @@ modules:
           url: https://proton.me/download/authenticator/linux/version.json
           version-query: .Releases[0].Version
           url-query: .Releases[0].File[0].Url
+          timestamp-query: .Releases[0].ReleaseDate
           is-main-source: true
 
       - type: file


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. Proton Authenticator is
  an open-source, end-to-end encrypted two-factor authentication app
  that generates TOTP codes locally and optionally syncs them across
  devices via a Proton Account.
- [ ] Please attach a video showcasing the application on Linux using
  the Flatpak.
- [x] The Flatpak ID follows all the rules listed in the Application ID
  requirements.
- [x] I have read and followed all the Submission requirements and the
  Submission guide and I agree to them.
- [ ] I am an upstream contributor to the project. The upstream
  developers have been made aware of this submission.

---

This is a continuation of #6978, which stalled on two open concerns.
Here is the current status of each.

#### Build from source

The upstream application (`ProtonMail/WebClients`) is a large yarn 4
(berry) + Rust/Tauri 2 monorepo. The previous submission noted that
`flatpak-node-generator` did not support yarn v2+ lockfiles at the
time; that limitation has since been resolved — yarn berry is now
supported via the `fiddle-yarn-berry` example in flatpak-builder-tools.

However, a full offline source build remains impractical for the
following reasons:

- The authenticator depends on roughly a dozen `@proton/*` workspace
  packages that are only available inside the monorepo. There is no
  standalone lockfile for just the authenticator — the root
  `yarn.lock` covers the entire monorepo.
- Generating a `generated-sources.json` from the full monorepo
  lockfile would produce an impractically large sources file.
- The Tauri/Rust backend requires `flatpak-cargo-generator` in
  addition to `flatpak-node-generator`, and the two must be
  coordinated against a single source tree.

We would welcome
a Flathub-exception decision or guidance on a practical path forward.

The submission packages the official pre-built
binary, which is GPL-3.0 licensed and freely redistributable. The
`only-arches: [x86_64]` restriction in both the manifest and
`flathub.json` reflects this accurately.

#### aarch64 support

Upstream does not publish an aarch64 binary. A source build (see
above) would resolve this. The `flathub.json` correctly restricts
the build to `x86_64` until that becomes possible.

---

#### Changes since #6978

**Manifest (`me.proton.Authenticator.yml`)**
- Install the Debian `copyright` file as the required license artifact
  at `$FLATPAK_DEST/share/licenses/$FLATPAK_ID/LICENSE`
- Use `${FLATPAK_DEST}` consistently across all `install` commands
- Add `timestamp-query: .Releases[0].ReleaseDate` to `x-checker-data`
  so automated update PRs carry the correct release date
- Add inline comment on `only-arches` explaining the constraint

**Metainfo (`me.proton.Authenticator.metainfo.xml`)**
- Remove non-standard `<url>` and `<address>` children from
  `<developer>` — these are not valid AppStream elements and were
  causing `appstream-util validate` to fail in CI
- Update the community-package disclaimer to the Flathub-recommended
  wording
- Fix `<content_rating>`: `money-purchasing` was incorrectly set to
  `intense`; corrected to `none` (app is fully free). Added
  `social-info: mild` for optional account sync.
- Add `<url type="bugtracker">` pointing to the upstream issue tracker
- Expand `<releases>` from a single empty entry to the full six-release
  history (1.0.0–1.1.4) with dates from Proton's version API and
  descriptions from the upstream `CHANGELOG.md`
- Move `xml:lang="en"` from `<screenshot>` to `<caption>` per
  AppStream spec